### PR TITLE
Fix webhook IP authorization check

### DIFF
--- a/config/monobank-api.php
+++ b/config/monobank-api.php
@@ -4,4 +4,7 @@ return [
     'api_url' => env('MONOBANK_API_URL', 'https://api.monobank.ua/'),
     'webhook_domain' => env('MONOBANK_WEBHOOK_DOMAIN'),
     'webhook_key' => env('MONOBANK_WEBHOOK_KEY', 'webhook'),
+    'webhook_ips' => array_filter(
+        explode(',', env('MONOBANK_WEBHOOK_IPS', ''))
+    ),
 ];

--- a/src/Http/Requests/WebhookRequest.php
+++ b/src/Http/Requests/WebhookRequest.php
@@ -3,14 +3,16 @@
 namespace Sashalenz\MonobankApi\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Config;
 
 class WebhookRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return array_key_exists(
+        return in_array(
             $this->ip(),
-            $this->allowedIPs()
+            $this->allowedIPs(),
+            true
         );
     }
 
@@ -26,6 +28,6 @@ class WebhookRequest extends FormRequest
 
     private function allowedIPs(): array
     {
-        return [];
+        return Config::get('monobank-api.webhook_ips', []);
     }
 }

--- a/tests/WebhookRequestTest.php
+++ b/tests/WebhookRequestTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Sashalenz\MonobankApi\Http\Requests\WebhookRequest;
+
+it('authorizes requests from allowed IPs', function () {
+    config(['monobank-api.webhook_ips' => ['127.0.0.1']]);
+
+    $request = WebhookRequest::create('/', 'POST', [], [], [], ['REMOTE_ADDR' => '127.0.0.1']);
+    $request->setContainer(app());
+    $request->setRouteResolver(fn () => null);
+
+    expect($request->authorize())->toBeTrue();
+});
+
+it('rejects requests from unlisted IPs', function () {
+    config(['monobank-api.webhook_ips' => ['127.0.0.1']]);
+
+    $request = WebhookRequest::create('/', 'POST', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
+    $request->setContainer(app());
+    $request->setRouteResolver(fn () => null);
+
+    expect($request->authorize())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- fix webhook request authorization to check IP values instead of array keys
- allow configuring allowed webhook IPs via `monobank-api.webhook_ips`
- test that allowed and unlisted IPs authorize appropriately

## Testing
- `composer install` *(fails: curl error 56 while downloading packages)*
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c3b193c083259c58963073f7e13d