### PR TITLE
Fix statement date validation and support proxy option

### DIFF
--- a/src/ApiModels/BaseModel.php
+++ b/src/ApiModels/BaseModel.php
@@ -111,6 +111,7 @@ abstract class BaseModel
             cache: $this->canBeCached
                 ? $this->cacheSeconds
                 : null,
+            proxy: $this->proxy,
         );
 
         return $request->make();

--- a/src/ApiModels/Personal.php
+++ b/src/ApiModels/Personal.php
@@ -42,11 +42,11 @@ class Personal extends BaseModel
      */
     public function statement(string $account, int $dateFrom, ?int $dateTo = null): string
     {
-        if ($dateFrom > $dateTo) {
+        if (! is_null($dateTo) && $dateFrom > $dateTo) {
             throw new MonobankApiException('Date from must be less than date to');
         }
 
-        if ($dateTo > $dateFrom + 2682000) {
+        if (! is_null($dateTo) && $dateTo > $dateFrom + 2682000) {
             throw new MonobankApiException('Date to must be less than 31 days');
         }
 

--- a/tests/RequestProxyTest.php
+++ b/tests/RequestProxyTest.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Http;
 use Illuminate\Http\Client\Request as HttpRequest;
+use Illuminate\Support\Facades\Http;
 use Sashalenz\MonobankApi\Request as ApiRequest;
 
 it('passes proxy option to HTTP client', function () {

--- a/tests/RequestProxyTest.php
+++ b/tests/RequestProxyTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\Request as HttpRequest;
+use Sashalenz\MonobankApi\Request as ApiRequest;
+
+it('passes proxy option to HTTP client', function () {
+    config(['monobank-api.api_url' => 'https://api.test/']);
+    Http::fake(function (HttpRequest $request) {
+        expect($request->getOptions())->toHaveKey('proxy');
+        expect($request->getOptions()['proxy'])->toBe('http://proxy.test');
+
+        return Http::response([]);
+    });
+
+    $request = new ApiRequest(
+        method: 'test',
+        params: [],
+        headers: [],
+        isPost: false,
+        cache: null,
+        proxy: 'http://proxy.test',
+    );
+
+    $request->make();
+});

--- a/tests/StatementValidationTest.php
+++ b/tests/StatementValidationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use Sashalenz\MonobankApi\Exceptions\MonobankApiException;
+use Sashalenz\MonobankApi\MonobankApi;
+
+beforeEach(function () {
+    config(['monobank-api.api_url' => 'https://api.test/']);
+    Http::fake(['*' => Http::response([])]);
+});
+
+it('allows requesting statement without end date', function () {
+    MonobankApi::personal()->statement('acc', 1);
+})->expectNotToPerformAssertions();
+
+it('throws when start date is after end date', function () {
+    expect(fn () => MonobankApi::personal()->statement('acc', 5, 1))
+        ->toThrow(MonobankApiException::class);
+});
+
+it('throws when date range exceeds 31 days', function () {
+    $from = 1;
+    $to = $from + 2682001;
+
+    expect(fn () => MonobankApi::personal()->statement('acc', $from, $to))
+        ->toThrow(MonobankApiException::class);
+});


### PR DESCRIPTION
## Summary
- Pass proxy configuration to HTTP request builder
- Validate statement date ranges only when end date provided
- Cover proxy option and statement validation with tests

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c548694c832593ce0a99a53401f1