### PR TITLE
test: add enum coverage

### DIFF
--- a/tests/AccountTypeTest.php
+++ b/tests/AccountTypeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Sashalenz\MonobankApi\Enums\AccountType;
+
+it('contains expected account types', function () {
+    $values = array_map(fn (AccountType $case) => $case->value, AccountType::cases());
+
+    expect($values)->toBe([
+        'black',
+        'white',
+        'platinum',
+        'iron',
+        'fop',
+        'yellow',
+    ]);
+});
+

--- a/tests/AccountTypeTest.php
+++ b/tests/AccountTypeTest.php
@@ -14,4 +14,3 @@ it('contains expected account types', function () {
         'yellow',
     ]);
 });
-

--- a/tests/CashbackTypeTest.php
+++ b/tests/CashbackTypeTest.php
@@ -11,4 +11,3 @@ it('contains expected cashback types', function () {
         'Miles',
     ]);
 });
-

--- a/tests/CashbackTypeTest.php
+++ b/tests/CashbackTypeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Sashalenz\MonobankApi\Enums\CashbackType;
+
+it('contains expected cashback types', function () {
+    $values = array_map(fn (CashbackType $case) => $case->value, CashbackType::cases());
+
+    expect($values)->toBe([
+        'None',
+        'UAH',
+        'Miles',
+    ]);
+});
+


### PR DESCRIPTION
## Summary
- add tests for AccountType and CashbackType enums

## Testing
- `composer test` *(fails: vendor/bin/pest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c6c333448325a163a26ad2d1919b